### PR TITLE
fix: Added MDX support in production webpack config

### DIFF
--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -24,8 +24,16 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.mdx?$/,
+        test: /\.md$/,
         loader: "html-loader!markdown-loader?gfm=false"
+      },
+      {
+        test: /\.mdx$/,
+        exclude: /node_modules/,
+        use: [
+          { loader: "babel-loader" },
+          { loader: require.resolve("./loader.js") }
+        ]
       },
       {
         test: /\.(js|jsx)$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5908,9 +5908,9 @@ spectacle-renderer@^0.0.3:
     puppeteer "^0.12.0"
     yargs "^9.0.1"
 
-spectacle@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/spectacle/-/spectacle-5.1.0.tgz#efbe37bfdd080a7802a063e7a8a7a5032c37009a"
+spectacle@5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/spectacle/-/spectacle-5.2.2.tgz#b5e717c85db47fe5dd267ff6562b9463b24fc1bc"
   dependencies:
     deep-object-diff "^1.0.4"
     emotion "^8.0.8"


### PR DESCRIPTION
* Reverted #6 which fixed the bug, but introduced a new one - slides is no longer an array of components, but raw test of the index.mdx file
* Fixes #7